### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ English | [简体中文](./README.zh-CN.md)
 
 > _Model Context Protocol ([MCP](https://modelcontextprotocol.io/introduction)) Server for [bilibili.com](https://www.bilibili.com)._
 
+<a href="https://glama.ai/mcp/servers/@wangshunnn/bilibili-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wangshunnn/bilibili-mcp-server/badge" alt="bilibili Server MCP server" />
+</a>
+
 ## Features
 
 ### User Info


### PR DESCRIPTION
This PR adds a badge for the [bilibili MCP Server](https://glama.ai/mcp/servers/@wangshunnn/bilibili-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@wangshunnn/bilibili-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wangshunnn/bilibili-mcp-server/badge" alt="bilibili Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.